### PR TITLE
修复子路径出现空白页的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+record

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["Vue.volar"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2996,9 +2996,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3581,9 +3581,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -112,7 +112,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,6 +54,7 @@ export default defineConfig({
       }
     }
   },
-  // 打包配置（保留你原有的配置，比如 base）
-  base: './'
+  // 打包配置
+  // 使用绝对根路径，避免 history 路由在子路径刷新时资源地址解析错误
+  base: '/'
 })


### PR DESCRIPTION
本 PR 修复了前端在子路径刷新或直接访问子路由时出现空白页的问题。
https://github.com/Tsukimi-Yachiyo/YachiyoWeb/issues/1
根因是构建资源使用了相对路径，导致在 history 路由场景下，浏览器在子路径下解析静态资源地址错误，主脚本加载失败。

变更内容：

- 将构建资源基路径调整为绝对根路径，确保静态资源始终从站点根目录加载。
- 统一路由 history 的 base 配置，与构建基路径保持一致。
- 验证构建产物中 JS/CSS 资源引用为绝对路径，避免子路由刷新时路径漂移。
- 运行`npm install`时有漏洞警告，运行了`npm audit fix`更新了两个依赖